### PR TITLE
Fixed non working code with deprecated '+'

### DIFF
--- a/notebooks/ch-gates/oracles.ipynb
+++ b/notebooks/ch-gates/oracles.ipynb
@@ -216,7 +216,7 @@
     }
    ],
    "source": [
-    "qc = Uf + Vf.inverse()\n",
+    "qc = Uf.compose(Vf.inverse())\n",
     "qc.draw()"
    ]
   },
@@ -313,7 +313,7 @@
     }
    ],
    "source": [
-    "(Vf.inverse() + copy + Vf).draw()"
+    "(Vf.inverse().compose(copy).compose(Vf)).draw()"
    ]
   },
   {


### PR DESCRIPTION
Used the .compose function instead of the '+', this is also done used in the next chapter on Deutsch-Jozsa Algorithm

Before it gave the error:
TypeError: unsupported operand type(s) for +: 'QuantumCircuit' and 'QuantumCircuit'

I didn't actually install the book on my computer, just edited this in github. I did test this code change in the actual online book. That seemed to work.