### PR TITLE
Remove `ibm_quantum_widgets` package

### DIFF
--- a/notebooks/ch-labs/Lab02_Single_Qubit_Gates.ipynb
+++ b/notebooks/ch-labs/Lab02_Single_Qubit_Gates.ipynb
@@ -25,15 +25,12 @@
     "import numpy as np\n",
     "\n",
     "# Importing standard Qiskit libraries\n",
-    "from qiskit import QuantumCircuit, transpile, Aer, IBMQ, execute\n",
+    "from qiskit import QuantumCircuit, transpile, Aer, execute\n",
     "from qiskit.tools.jupyter import *\n",
     "from qiskit.visualization import *\n",
-    "from ibm_quantum_widgets import *\n",
     "from qiskit.providers.aer import QasmSimulator\n",
     "\n",
-    "# Loading your IBM Quantum account(s)\n",
-    "provider = IBMQ.load_account()\n",
-    "backend = Aer.get_backend('statevector_simulator')\n"
+    "backend = Aer.get_backend('statevector_simulator')"
    ]
   },
   {


### PR DESCRIPTION
This package has been removed from PyPI and was not used in this notebook anyway. Also removed unused IBMQ import while at it.
