### PR TITLE
Change platform-based issues link to Platypus

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Appearance / website issues 💅
-    url: https://github.com/Qiskit/saiba/issues/new/choose
-    about: Open an issue in the Saiba repository.
+    url: https://github.com/Qiskit/platypus/issues/new/choose
+    about: Open an issue in the Platypus repository.


### PR DESCRIPTION
We're still currently using Platypus for the website, so website-based issues should go to Platypus. Fixes #17.