### PR TITLE
New Page on Error Correction with Surface Codes

### DIFF
--- a/notebooks/quantum-hardware/error-correction-surface-code.ipynb
+++ b/notebooks/quantum-hardware/error-correction-surface-code.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Surface codes are a group of error-correcting quantum codes that seek to leverage topology to create logical qubits [0]. Surface codes are variants of toric and planar codes, which simple codes designed for topological order. Pivotal to the field of quantum error correction, surface codes are renowned for having a high tolerance to errors. In this page, we will discuss the basic theory behind a two-dimensional, planar surface code, implementation, and the future of the surface code for further research."
+    "Surface codes are a group of error-correcting quantum codes that seek to leverage topology to create logical qubits [0]. Surface codes are variants of toric and planar codes, which simple codes designed for topological order. Pivotal to the field of quantum error correction, surface codes are renowned for having a high tolerance to errors. Unlike the repetition code discussed in earlier pages, the surface code can correct bit flips and phase flips simultaneously. In this page, we will discuss the basic theory behind a two-dimensional, surface code, implementation, and the future of the surface code for further research."
    ]
   },
   {
@@ -23,21 +23,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Theory\n",
+    "## Encoding a Logical Qubit \n",
+    "\n",
+    "In the surface code, physical qubits are entangled using CNOT gates"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Code Qubits"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### X and Z Stabilizers\n",
     "\n"
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Initializing the Circuit "
+    "from qiskit.providers.aer.noise import NoiseModel\n",
+    "from qiskit.providers.aer.noise.errors import pauli_error, depolarizing_error\n",
+    "\n",
+    "def get_noise(p):\n",
+    "    error_meas = pauli_error([('X',p), ('I', 1 - p)])\n",
+    "\n",
+    "    noise_model = NoiseModel()\n",
+    "    noise_model.add_all_qubit_quantum_error(error_meas, \"measure\") # measurement error is applied to measurements\n",
+    "        \n",
+    "    return noise_model\n",
+    "\n",
+    "noise_model=get_noise(.01)"
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Decoding and Correcting Errors"
+    "### Decoding and Correcting Errors"
    ]
   },
   {
@@ -72,22 +108,44 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from topological_codes import SurfaceCode\n",
-    "from topological_codes import lookuptable_decoding\n",
-    "from topological_codes import GraphDecoder"
+    "Now that we know how to implement a surface code. In this page, we will use "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from topological_codes import SurfaceCode, lookuptable_decoding\n",
+    "from qiskit import Aer,execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend=Aer.get_backend('aer_simulator')\n",
+    "surface_code=SurfaceCode(3,3)\n",
+    "raw={}\n",
+    "raw['0']=execute(surface_code.circuit['0'], backend, noise_model=noise_model).result().get_counts()\n",
+    "raw['1']=execute(surface_code.circuit ['1'], backend, noise_model=noise_model).result().get_counts()\n",
+    "surface_code.process_results(raw)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## $\\hat{X}$ and $\\hat{Z}$ Operations"
+   ]
   },
   {
    "attachments": {},
@@ -102,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Further Research"
+    "### Further Research"
    ]
   },
   {
@@ -123,13 +181,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.21.1</td></tr><tr><td><code>qiskit-aer</code></td><td>0.10.4</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit</code></td><td>0.37.1</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.4.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.10.4</td></tr><tr><td>Python compiler</td><td>MSC v.1916 64 bit (AMD64)</td></tr><tr><td>Python build</td><td>main, Mar 30 2022 08:38:02</td></tr><tr><td>OS</td><td>Windows</td></tr><tr><td>CPUs</td><td>6</td></tr><tr><td>Memory (Gb)</td><td>15.928573608398438</td></tr><tr><td colspan='2'>Thu Jun 29 16:14:50 2023 Eastern Daylight Time</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.21.1</td></tr><tr><td><code>qiskit-aer</code></td><td>0.10.4</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit</code></td><td>0.37.1</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.4.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.10.4</td></tr><tr><td>Python compiler</td><td>MSC v.1916 64 bit (AMD64)</td></tr><tr><td>Python build</td><td>main, Mar 30 2022 08:38:02</td></tr><tr><td>OS</td><td>Windows</td></tr><tr><td>CPUs</td><td>6</td></tr><tr><td>Memory (Gb)</td><td>15.928569793701172</td></tr><tr><td colspan='2'>Sat Jul 01 02:03:04 2023 Eastern Daylight Time</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"

--- a/notebooks/quantum-hardware/error-correction-surface-code.ipynb
+++ b/notebooks/quantum-hardware/error-correction-surface-code.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quantum Error Correction with Surface Codes"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Surface codes are a group of error-correcting quantum codes that seek to leverage topology to create logical qubits [0]. Surface codes are variants of toric and planar codes, which simple codes designed for topological order. Pivotal to the field of quantum error correction, surface codes are renowned for having a high tolerance to errors. In this page, we will discuss the basic theory behind a two-dimensional, planar surface code, implementation, and the future of the surface code for further research."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Theory\n",
+    "\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initializing the Circuit "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit import Aer, QuantumRegister, ClassicalRegister\n",
+    "from qiskit.visualization import plot_histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend=Aer.get_backend('aer_simulator')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Decoding and Correcting Errors"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Qiskit Implementation\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from topological_codes import SurfaceCode\n",
+    "from topological_codes import lookuptable_decoding\n",
+    "from topological_codes import GraphDecoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Further Research"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "[0] https://arxiv.org/abs/1208.0928"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.21.1</td></tr><tr><td><code>qiskit-aer</code></td><td>0.10.4</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit</code></td><td>0.37.1</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.4.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.10.4</td></tr><tr><td>Python compiler</td><td>MSC v.1916 64 bit (AMD64)</td></tr><tr><td>Python build</td><td>main, Mar 30 2022 08:38:02</td></tr><tr><td>OS</td><td>Windows</td></tr><tr><td>CPUs</td><td>6</td></tr><tr><td>Memory (Gb)</td><td>15.928573608398438</td></tr><tr><td colspan='2'>Thu Jun 29 16:14:50 2023 Eastern Daylight Time</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import qiskit.tools.jupyter\n",
+    "%qiskit_version_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "data_sci",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The surface code is pivotal to the field of quantum error correction code; for this reason, I think it is useful to introduce the surface code for teaching quantum computing. I noticed that the surface code already has a qiskit implementation under the `topological_codes` module; it also provided the qiskit implementation of repetition codes in "Introduction to Quantum Error Correction via the Repetition Code". A link to a [few tutorials](https://github.com/quantumjim/TopologicalCodesTutorial/tree/main) by James R. Wooten can be found in the [README ](https://github.com/NCCR-SPIN/topological_codes/blob/master/README.md)of `topological_codes`, but these are not currently accessible by the qiskit textbook. Second, I placed the page in the "Quantum Hardware" chapter because the previous page regarding repetition codes and introduction to error correction introduced key error correction concepts like ancilla qubits, stabilization, parity, and decoding. I intend to use [Martini's introduction of the surface code](https://arxiv.org/abs/1208.0928) and [Wooten's slideshow](https://github.com/quantumjim/Quantum-Computation-course-Basel/blob/main/extra_resources/Surface-codes.pptx) as outlines for this page. This new page is a skeleton of the final product and will undergo many commits.