### PR TITLE
Issue-69: The AerSimulator is imported from the 'qiskit_aer' package.

### DIFF
--- a/notebooks/intro/atoms-of-computation.ipynb
+++ b/notebooks/intro/atoms-of-computation.ipynb
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.providers.aer import AerSimulator  # pylint: disable=import-error, no-name-in-module\n",
+    "from qiskit_aer import AerSimulator  # pylint: disable=import-error, no-name-in-module\n",
     "sim = AerSimulator()  # make new simulator object"
    ]
   },


### PR DESCRIPTION
<!-- 
Thank you for helping us improve!
Please try to be as clear as possible, and paste a link to the page that contains the problem.
-->

**Where is the problem?**
https://learn.qiskit.org/course/introduction/the-atoms-of-computation

**Describe the problem**
In the "Your first quantum circuit" section the package that is used to import the `AerSimulator` is incorrect.
**Expected behavior**
Instead of importing the `AerSimulator` from `qiskit.providers.aer` it should be imported from `qiskit_aer`. At least this is what works locally.