### PR TITLE
Fixed Wrong URL Of QPE Notebook In Shor's Algo Notebook

### DIFF
--- a/notebooks/ch-algorithms/shor.ipynb
+++ b/notebooks/ch-algorithms/shor.ipynb
@@ -133,7 +133,7 @@
    "source": [
     "## 2. The Solution\n",
     "\n",
-    "Shor’s solution was to use [quantum phase estimation](./quantum-phase-estimation.html) on the unitary operator:\n",
+    "Shor’s solution was to use [quantum phase estimation](./quantum-phase-estimation.ipynb) on the unitary operator:\n",
     "\n",
     "$$ U|y\\rangle \\equiv |ay \\bmod N \\rangle $$\n",
     "\n",


### PR DESCRIPTION
In Shor's algorithm notebook, link to QPE is pointing to the wrong location.

![image](https://github.com/Qiskit/textbook/assets/26363918/825b3ea0-4926-46b6-8c16-18e5e05edfd6)
![image](https://github.com/Qiskit/textbook/assets/26363918/1e9ac5fb-18b4-44d8-ba32-c19de5371a0e)


Wrong URL:- https://github.com/Qiskit/textbook/blob/aebdd2bc86ddb7a79dd8441d52c839d312ffafbb/notebooks/ch-algorithms/quantum-phase-estimation.html

Correct URL:- https://github.com/Qiskit/textbook/blob/aebdd2bc86ddb7a79dd8441d52c839d312ffafbb/notebooks/ch-algorithms/quantum-phase-estimation.ipynb